### PR TITLE
Update SLAnalyticsTypes

### DIFF
--- a/AddRADParameterGroup/AddRADParameterGroup.cs
+++ b/AddRADParameterGroup/AddRADParameterGroup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AddParameterGroup;
+using RadDataSourceUtils;
 using RadWidgets;
 using Skyline.DataMiner.Analytics.Mad;
 using Skyline.DataMiner.Automation;
@@ -73,8 +74,7 @@ public class Script
 		{
 			try
 			{
-				var message = new AddMADParameterGroupMessage(group);
-				_app.Engine.SendSLNetSingleResponseMessage(message);
+				RadMessageHelper.AddParameterGroup(_app.Engine, group);
 			}
 			catch (Exception ex)
 			{

--- a/AddRADParameterGroup/AddRADParameterGroup.cs
+++ b/AddRADParameterGroup/AddRADParameterGroup.cs
@@ -2,9 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AddParameterGroup;
-using RadDataSourceUtils;
+using RadUtils;
 using RadWidgets;
-using Skyline.DataMiner.Analytics.Mad;
 using Skyline.DataMiner.Automation;
 using Skyline.DataMiner.Utils.InteractiveAutomationScript;
 
@@ -86,7 +85,7 @@ public class Script
 		if (failedGroups.Count > 0)
 		{
 			var ex = new AggregateException("Failed to add parameter group(s) to RAD configuration", failedGroups.Select(p => p.Item2));
-			Utils.ShowExceptionDialog(_app, $"Failed to create {failedGroups.Select(p => p.Item1).HumanReadableJoin()}", ex, dialog);
+			RadWidgets.Utils.ShowExceptionDialog(_app, $"Failed to create {failedGroups.Select(p => p.Item1).HumanReadableJoin()}", ex, dialog);
 
 			return;
 		}

--- a/AddRADParameterGroup/AddRADParameterGroup.csproj
+++ b/AddRADParameterGroup/AddRADParameterGroup.csproj
@@ -11,7 +11,7 @@
     <VersionComment>Initial Version</VersionComment>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.4.1" />
+    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5.2" />
     <PackageReference Include="Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit" Version="10.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/EditRADParameterGroup/EditRADParameterGroup.cs
+++ b/EditRADParameterGroup/EditRADParameterGroup.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 using EditRADParameterGroup;
-using RadDataSourceUtils;
+using RadUtils;
 using RadWidgets;
 using Skyline.DataMiner.Analytics.Mad;
 using Skyline.DataMiner.Automation;
@@ -28,15 +28,15 @@ public class Script
 		{
 			_app = new InteractiveController(engine);
 
-			var groupNamesAndIds = Utils.GetGroupNameAndDataMinerID(_app);
+			var groupNamesAndIds = RadWidgets.Utils.GetGroupNameAndDataMinerID(_app);
 			if (groupNamesAndIds.Count == 0)
 			{
-				Utils.ShowMessageDialog(_app, "No parameter group selected", "Please select the parameter group you want to edit first");
+				RadWidgets.Utils.ShowMessageDialog(_app, "No parameter group selected", "Please select the parameter group you want to edit first");
 				return;
 			}
 			else if (groupNamesAndIds.Count > 1)
 			{
-				Utils.ShowMessageDialog(_app, "Multiple parameter groups selected", "Please select a single parameter group you want to edit");
+				RadWidgets.Utils.ShowMessageDialog(_app, "Multiple parameter groups selected", "Please select a single parameter group you want to edit");
 				return;
 			}
 
@@ -48,7 +48,7 @@ public class Script
 				var groupInfo = RadMessageHelper.FetchParameterGroupInfo(_app.Engine, dataMinerID, groupName);
 				if (groupInfo == null)
 				{
-					Utils.ShowMessageDialog(
+					RadWidgets.Utils.ShowMessageDialog(
 						_app,
 						"Failed to fetch parameter group information",
 						"Failed to fetch parameter group information: no response or a response of the wrong type received");
@@ -69,7 +69,7 @@ public class Script
 			}
 			catch (Exception ex)
 			{
-				Utils.ShowExceptionDialog(_app, "Failed to fetch parameter group information", ex);
+				RadWidgets.Utils.ShowExceptionDialog(_app, "Failed to fetch parameter group information", ex);
 				return;
 			}
 
@@ -123,7 +123,7 @@ public class Script
 		}
 		catch (Exception ex)
 		{
-			Utils.ShowExceptionDialog(_app, "Failed to add parameter group(s) to RAD configuration", ex, dialog);
+			RadWidgets.Utils.ShowExceptionDialog(_app, "Failed to add parameter group(s) to RAD configuration", ex, dialog);
 			return;
 		}
 

--- a/EditRADParameterGroup/EditRADParameterGroup.csproj
+++ b/EditRADParameterGroup/EditRADParameterGroup.csproj
@@ -12,7 +12,7 @@
     <VersionComment>Initial Version</VersionComment>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.4.1" />
+    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5.2" />
     <PackageReference Include="Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit" Version="10.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/RAD Manager.sln
+++ b/RAD Manager.sln
@@ -73,8 +73,8 @@ Global
 		SolutionGuid = {C0C090A6-5A8E-4200-87E5-92D361756E2E}
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		RadUtils\RadDataSourceUtils.projitems*{2ade4ecb-223a-40e2-b795-2f33a74d70d8}*SharedItemsImports = 13
-		RadUtils\RadDataSourceUtils.projitems*{391c490f-138c-4cd1-90f2-5514f6c8315a}*SharedItemsImports = 5
-		RadUtils\RadDataSourceUtils.projitems*{af76190b-a00f-476b-ab49-e07ad7a67e4d}*SharedItemsImports = 5
+		RadUtils\RadUtils.projitems*{2ade4ecb-223a-40e2-b795-2f33a74d70d8}*SharedItemsImports = 13
+		RadUtils\RadUtils.projitems*{391c490f-138c-4cd1-90f2-5514f6c8315a}*SharedItemsImports = 5
+		RadUtils\RadUtils.projitems*{af76190b-a00f-476b-ab49-e07ad7a67e4d}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/RAD Manager/RAD Manager.csproj
+++ b/RAD Manager/RAD Manager.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Skyline.DataMiner.Core.AppPackageInstaller" Version="2.0.5" />
-    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.4.1" />
+    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">

--- a/RADDataSources/RADDataSources.csproj
+++ b/RADDataSources/RADDataSources.csproj
@@ -12,7 +12,7 @@
     <VersionComment>Initial Version</VersionComment>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.4.1" />
+    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">

--- a/RADDataSources/RADDataSources.csproj
+++ b/RADDataSources/RADDataSources.csproj
@@ -20,5 +20,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  <Import Project="..\RadUtils\RadDataSourceUtils.projitems" Label="Shared" />
+  <Import Project="..\RadUtils\RadUtils.projitems" Label="Shared" />
 </Project>

--- a/RADDataSources/RelationalAnomalyGroupsDataSource.cs
+++ b/RADDataSources/RelationalAnomalyGroupsDataSource.cs
@@ -3,10 +3,9 @@ namespace RadDataSources
 	using System;
 	using System.Collections.Generic;
 	using System.Linq;
-	using RadDataSourceUtils;
+	using RadUtils;
 	using Skyline.DataMiner.Analytics.DataTypes;
 	using Skyline.DataMiner.Analytics.GenericInterface;
-	using Skyline.DataMiner.Analytics.Mad;
 	using Skyline.DataMiner.Net.Messages;
 
 	/// <summary>

--- a/RADDataSources/RelationalAnomalyScoreDataSource.cs
+++ b/RADDataSources/RelationalAnomalyScoreDataSource.cs
@@ -79,7 +79,7 @@ namespace RadDataSources
 			try
 			{
 				_anomalyScoreData.AnomalyScores.Clear();
-				var madDataResponse = RadMessageHelper.FetchRADData(ConnectionHelper.Connection, _dataMinerID, _groupName, _startTime.Value, _endTime.Value);
+				var madDataResponse = RadMessageHelper.FetchRADData(ConnectionHelper.Connection, _dataMinerID, _groupName, DateTime.Now.AddMonths(-1), DateTime.Now);
 				_logger.Information($"Number of points: {madDataResponse?.Data.Count}");
 				if (madDataResponse != null)
 				{

--- a/RADDataSources/RelationalAnomalyScoreDataSource.cs
+++ b/RADDataSources/RelationalAnomalyScoreDataSource.cs
@@ -3,7 +3,7 @@ namespace RadDataSources
 	using System;
 	using System.Collections.Generic;
 	using System.Linq;
-	using RadDataSourceUtils;
+	using RadUtils;
 	using Skyline.DataMiner.Analytics.GenericInterface;
 	using Skyline.DataMiner.Analytics.Mad;
 	using Skyline.DataMiner.Net.Exceptions;
@@ -79,7 +79,7 @@ namespace RadDataSources
 			try
 			{
 				_anomalyScoreData.AnomalyScores.Clear();
-				var madDataResponse = RadMessageHelper.FetchRADData(ConnectionHelper.Connection, _dataMinerID, _groupName, _startTime, _endTime);
+				var madDataResponse = RadMessageHelper.FetchRADData(ConnectionHelper.Connection, _dataMinerID, _groupName, _startTime.Value, _endTime.Value);
 				_logger.Information($"Number of points: {madDataResponse?.Data.Count}");
 				if (madDataResponse != null)
 				{

--- a/RADDataSources/RelationalAnomalyScoreDataSource.cs
+++ b/RADDataSources/RelationalAnomalyScoreDataSource.cs
@@ -3,6 +3,7 @@ namespace RadDataSources
 	using System;
 	using System.Collections.Generic;
 	using System.Linq;
+	using RadDataSourceUtils;
 	using Skyline.DataMiner.Analytics.GenericInterface;
 	using Skyline.DataMiner.Analytics.Mad;
 	using Skyline.DataMiner.Net.Exceptions;
@@ -78,15 +79,11 @@ namespace RadDataSources
 			try
 			{
 				_anomalyScoreData.AnomalyScores.Clear();
-				GetMADDataMessage msg = new GetMADDataMessage(_groupName, DateTime.Now.AddMonths(-1), DateTime.Now)
+				var madDataResponse = RadMessageHelper.FetchRADData(ConnectionHelper.Connection, _dataMinerID, _groupName, _startTime, _endTime);
+				_logger.Information($"Number of points: {madDataResponse?.Data.Count}");
+				if (madDataResponse != null)
 				{
-					DataMinerID = _dataMinerID,
-				};
-				var madDataReponse = ConnectionHelper.Connection.HandleSingleResponseMessage(msg) as GetMADDataResponseMessage;
-				_logger.Information($"Number of points: {madDataReponse?.Data.Count}");
-				if (madDataReponse != null)
-				{
-					foreach (MADDataPoint point in madDataReponse.Data)
+					foreach (MADDataPoint point in madDataResponse.Data)
 					{
 						_anomalyScoreData.AnomalyScores.Add(new KeyValuePair<DateTime, double>(point.Timestamp, point.AnomalyScore));
 					}

--- a/RADDataSources/RelationalGroupInfoDataSource.cs
+++ b/RADDataSources/RelationalGroupInfoDataSource.cs
@@ -3,7 +3,7 @@ namespace RadDataSources
 	using System;
 	using System.Collections.Generic;
 	using System.Linq;
-	using RadDataSourceUtils;
+	using RadUtils;
 	using Skyline.DataMiner.Analytics.DataTypes;
 	using Skyline.DataMiner.Analytics.GenericInterface;
 	using Skyline.DataMiner.Analytics.Mad;

--- a/RADDataSources/RelationalGroupInfoDataSource.cs
+++ b/RADDataSources/RelationalGroupInfoDataSource.cs
@@ -3,6 +3,7 @@ namespace RadDataSources
 	using System;
 	using System.Collections.Generic;
 	using System.Linq;
+	using RadDataSourceUtils;
 	using Skyline.DataMiner.Analytics.DataTypes;
 	using Skyline.DataMiner.Analytics.GenericInterface;
 	using Skyline.DataMiner.Analytics.Mad;
@@ -61,13 +62,9 @@ namespace RadDataSources
 
 			try
 			{
-				GetMADParameterGroupInfoMessage msg = new GetMADParameterGroupInfoMessage(_groupName)
-				{
-					DataMinerID = _dataMinerID,
-				};
-				var groupInfoResponse = ConnectionHelper.Connection.HandleSingleResponseMessage(msg) as GetMADParameterGroupInfoResponseMessage;
-				if (groupInfoResponse?.GroupInfo != null)
-					_parameterKeys = groupInfoResponse.GroupInfo.Parameters;
+				var groupInfo = RadMessageHelper.FetchParameterGroupInfo(ConnectionHelper.Connection, _dataMinerID, _groupName);
+				if (groupInfo != null)
+					_parameterKeys = groupInfo.Parameters;
 			}
 			catch (Exception ex)
 			{

--- a/RADWidgets/RadWidgets.csproj
+++ b/RADWidgets/RadWidgets.csproj
@@ -23,5 +23,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  <Import Project="..\RadUtils\RadDataSourceUtils.projitems" Label="Shared" />
+  <Import Project="..\RadUtils\RadUtils.projitems" Label="Shared" />
 </Project>

--- a/RADWidgets/RadWidgets.csproj
+++ b/RADWidgets/RadWidgets.csproj
@@ -13,6 +13,7 @@
     <VersionComment>Initial Version</VersionComment>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Skyline.DataMiner.Core.DataMinerSystem.Automation" Version="1.1.2.2" />
     <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5.2" />
     <PackageReference Include="Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit" Version="10.0.5" />
   </ItemGroup>

--- a/RADWidgets/RadWidgets.csproj
+++ b/RADWidgets/RadWidgets.csproj
@@ -13,7 +13,7 @@
     <VersionComment>Initial Version</VersionComment>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.4.1" />
+    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5.2" />
     <PackageReference Include="Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit" Version="10.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/RADWidgets/Utils.cs
+++ b/RADWidgets/Utils.cs
@@ -4,7 +4,7 @@
 	using System.Collections.Generic;
 	using System.Linq;
 	using System.Text;
-	using RadDataSourceUtils;
+	using RadUtils;
 	using Skyline.DataMiner.Automation;
 	using Skyline.DataMiner.Core.DataMinerSystem.Automation;
 	using Skyline.DataMiner.Core.DataMinerSystem.Common;

--- a/RADWidgets/Utils.cs
+++ b/RADWidgets/Utils.cs
@@ -4,8 +4,10 @@
 	using System.Collections.Generic;
 	using System.Linq;
 	using System.Text;
-	using Skyline.DataMiner.Analytics.Mad;
+	using RadDataSourceUtils;
 	using Skyline.DataMiner.Automation;
+	using Skyline.DataMiner.Core.DataMinerSystem.Automation;
+	using Skyline.DataMiner.Core.DataMinerSystem.Common;
 	using Skyline.DataMiner.Net.Helper;
 	using Skyline.DataMiner.Net.Messages;
 	using Skyline.DataMiner.Utils.InteractiveAutomationScript;
@@ -171,23 +173,27 @@
 
 		public static List<string> FetchRadGroupNames(IEngine engine)
 		{
-			try
+			var result = new List<string>();
+			foreach (var agent in engine.GetDms().GetAgents())
 			{
-				var request = new GetMADParameterGroupsMessage();
-				var response = engine.SendSLNetSingleResponseMessage(request) as GetMADParameterGroupsResponseMessage;
-				if (response == null)
+				try
 				{
-					engine.Log("Could not fetch RAD group names: no response or response of the wrong type received", LogType.Error, 5);
-					return new List<string> { };
-				}
+					var response = RadMessageHelper.FetchParameterGroups(engine, agent.Id);
+					if (response == null)
+					{
+						engine.Log("Could not fetch RAD group names: no response or response of the wrong type received", LogType.Error, 5);
+						return new List<string> { };
+					}
 
-				return response.GroupNames;
+					return response.GroupNames;
+				}
+				catch (Exception e)
+				{
+					engine.Log($"Could not fetch RAD group names: {e}", LogType.Error, 5);
+				}
 			}
-			catch (Exception e)
-			{
-				engine.Log($"Could not fetch RAD group names: {e}", LogType.Error, 5);
-				return new List<string>() { };
-			}
+
+			return result;
 		}
 
 		/// <summary>

--- a/RadUtils/RadDataSourceUtils.projitems
+++ b/RadUtils/RadDataSourceUtils.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Cache.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RadMessageHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ParametersCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils.cs" />
   </ItemGroup>

--- a/RadUtils/RadMessageHelper.cs
+++ b/RadUtils/RadMessageHelper.cs
@@ -3,7 +3,6 @@
 	using System;
 	using System.Collections.Generic;
 	using Skyline.DataMiner.Analytics.Mad;
-	using Skyline.DataMiner.Analytics.Rad;
 	using Skyline.DataMiner.Automation;
 	using Skyline.DataMiner.Net;
 	using Skyline.DataMiner.Net.Messages;
@@ -43,22 +42,22 @@
 			return FetchRADData(engine.SendSLNetSingleResponseMessage, dataMinerID, groupName, startTime, endTime);
 		}
 
-		public static RemoveRADParameterGroupResponseMessage RemoveParameterGroup(Connection connection, int dataMinerID, string groupName)
+		public static RemoveMADParameterGroupResponseMessage RemoveParameterGroup(Connection connection, int dataMinerID, string groupName)
 		{
 			return RemoveParameterGroup(connection.HandleSingleResponseMessage, dataMinerID, groupName);
 		}
 
-		public static RemoveRADParameterGroupResponseMessage RemoveParameterGroup(IEngine engine, int dataMinerID, string groupName)
+		public static RemoveMADParameterGroupResponseMessage RemoveParameterGroup(IEngine engine, int dataMinerID, string groupName)
 		{
 			return RemoveParameterGroup(engine.SendSLNetSingleResponseMessage, dataMinerID, groupName);
 		}
 
-		public static AddRADParameterGroupResponseMessage AddParameterGroup(Connection connection, MADGroupInfo groupInfo)
+		public static AddMADParameterGroupResponseMessage AddParameterGroup(Connection connection, MADGroupInfo groupInfo)
 		{
 			return AddParameterGroup(connection.HandleSingleResponseMessage, groupInfo);
 		}
 
-		public static AddRADParameterGroupResponseMessage AddParameterGroup(IEngine engine, MADGroupInfo groupInfo)
+		public static AddMADParameterGroupResponseMessage AddParameterGroup(IEngine engine, MADGroupInfo groupInfo)
 		{
 			return AddParameterGroup(engine.SendSLNetSingleResponseMessage, groupInfo);
 		}
@@ -112,7 +111,7 @@
 			return sendMessageFunc(request) as GetMADDataResponseMessage;
 		}
 
-		private static RemoveRADParameterGroupResponseMessage RemoveParameterGroup(
+		private static RemoveMADParameterGroupResponseMessage RemoveParameterGroup(
 			Func<DMSMessage, DMSMessage> sendMessageFunc,
 			int dataMinerID,
 			string groupName)
@@ -121,15 +120,15 @@
 			{
 				DataMinerID = dataMinerID,
 			};
-			return sendMessageFunc(request) as RemoveRADParameterGroupResponseMessage;
+			return sendMessageFunc(request) as RemoveMADParameterGroupResponseMessage;
 		}
 
-		private static AddRADParameterGroupResponseMessage AddParameterGroup(
+		private static AddMADParameterGroupResponseMessage AddParameterGroup(
 			Func<DMSMessage, DMSMessage> sendMessageFunc,
 			MADGroupInfo groupInfo)
 		{
 			var request = new AddMADParameterGroupMessage(groupInfo);
-			return sendMessageFunc(request) as AddRADParameterGroupResponseMessage;
+			return sendMessageFunc(request) as AddMADParameterGroupResponseMessage;
 		}
 
 		private static RetrainMADModelResponseMessage RetrainParameterGroup(

--- a/RadUtils/RadMessageHelper.cs
+++ b/RadUtils/RadMessageHelper.cs
@@ -63,12 +63,12 @@
 			return AddParameterGroup(engine.SendSLNetSingleResponseMessage, groupInfo);
 		}
 
-		public static RetrainMADModelResponseMessage RetrainParameterGroup(Connection connection, int dataMinerID, string groupName, List<TimeRange> timeRanges)
+		public static RetrainMADModelResponseMessage RetrainParameterGroup(Connection connection, int dataMinerID, string groupName, List<Skyline.DataMiner.Analytics.Mad.TimeRange> timeRanges)
 		{
 			return RetrainParameterGroup(connection.HandleSingleResponseMessage, dataMinerID, groupName, timeRanges);
 		}
 
-		public static RetrainMADModelResponseMessage RetrainParameterGroup(IEngine engine, int dataMinerID, string groupName, List<TimeRange> timeRanges)
+		public static RetrainMADModelResponseMessage RetrainParameterGroup(IEngine engine, int dataMinerID, string groupName, List<Skyline.DataMiner.Analytics.Mad.TimeRange> timeRanges)
 		{
 			return RetrainParameterGroup(engine.SendSLNetSingleResponseMessage, dataMinerID, groupName, timeRanges);
 		}
@@ -136,7 +136,7 @@
 			Func<DMSMessage, DMSMessage> sendMessageFunc,
 			int dataMinerID,
 			string groupName,
-			List<TimeRange> timeRanges)
+			List<Skyline.DataMiner.Analytics.Mad.TimeRange> timeRanges)
 		{
 			var request = new RetrainMADModelMessage(groupName, timeRanges)
 			{

--- a/RadUtils/RadMessageHelper.cs
+++ b/RadUtils/RadMessageHelper.cs
@@ -1,0 +1,148 @@
+﻿namespace RadDataSourceUtils
+{
+	using System;
+	using System.Collections.Generic;
+	using Skyline.DataMiner.Analytics.Mad;
+	using Skyline.DataMiner.Analytics.Rad;
+	using Skyline.DataMiner.Automation;
+	using Skyline.DataMiner.Net;
+	using Skyline.DataMiner.Net.Messages;
+
+	/// <summary>
+	/// Class with helper functions to fetch messages from the DataMiner.
+	/// </summary>
+	public static class RadMessageHelper
+	{
+		public static GetMADParameterGroupsResponseMessage FetchParameterGroups(Connection connection, int dataMinerID)
+		{
+			return FetchParameterGroups(connection.HandleSingleResponseMessage, dataMinerID);
+		}
+
+		public static GetMADParameterGroupsResponseMessage FetchParameterGroups(IEngine engine, int dataMinerID)
+		{
+			return FetchParameterGroups(engine.SendSLNetSingleResponseMessage, dataMinerID);
+		}
+
+		public static MADGroupInfo FetchParameterGroupInfo(Connection connection, int dataMinerID, string groupName)
+		{
+			return FetchParameterGroupInfo(connection.HandleSingleResponseMessage, dataMinerID, groupName);
+		}
+
+		public static MADGroupInfo FetchParameterGroupInfo(IEngine engine, int dataMinerID, string groupName)
+		{
+			return FetchParameterGroupInfo(engine.SendSLNetSingleResponseMessage, dataMinerID, groupName);
+		}
+
+		public static GetMADDataResponseMessage FetchRADData(Connection connection, int dataMinerID, string groupName, DateTime startTime, DateTime endTime)
+		{
+			return FetchRADData(connection.HandleSingleResponseMessage, dataMinerID, groupName, startTime, endTime);
+		}
+
+		public static GetMADDataResponseMessage FetchRADData(IEngine engine, int dataMinerID, string groupName, DateTime startTime, DateTime endTime)
+		{
+			return FetchRADData(engine.SendSLNetSingleResponseMessage, dataMinerID, groupName, startTime, endTime);
+		}
+
+		public static RemoveRADParameterGroupResponseMessage RemoveParameterGroup(Connection connection, int dataMinerID, string groupName)
+		{
+			return RemoveParameterGroup(connection.HandleSingleResponseMessage, dataMinerID, groupName);
+		}
+
+		public static RemoveRADParameterGroupResponseMessage RemoveParameterGroup(IEngine engine, int dataMinerID, string groupName)
+		{
+			return RemoveParameterGroup(engine.SendSLNetSingleResponseMessage, dataMinerID, groupName);
+		}
+
+		public static AddRADParameterGroupResponseMessage AddParameterGroup(Connection connection, MADGroupInfo groupInfo)
+		{
+			return AddParameterGroup(connection.HandleSingleResponseMessage, groupInfo);
+		}
+
+		public static AddRADParameterGroupResponseMessage AddParameterGroup(IEngine engine, MADGroupInfo groupInfo)
+		{
+			return AddParameterGroup(engine.SendSLNetSingleResponseMessage, groupInfo);
+		}
+
+		public static RetrainMADModelResponseMessage RetrainParameterGroup(Connection connection, int dataMinerID, string groupName, List<TimeRange> timeRanges)
+		{
+			return RetrainParameterGroup(connection.HandleSingleResponseMessage, dataMinerID, groupName, timeRanges);
+		}
+
+		public static RetrainMADModelResponseMessage RetrainParameterGroup(IEngine engine, int dataMinerID, string groupName, List<TimeRange> timeRanges)
+		{
+			return RetrainParameterGroup(engine.SendSLNetSingleResponseMessage, dataMinerID, groupName, timeRanges);
+		}
+
+
+#pragma warning disable CS0618 // Type or member is obsolete: messages are obsolete since 10.5.5, but replacements were only added in that version
+		private static GetMADParameterGroupsResponseMessage FetchParameterGroups(Func<DMSMessage, DMSMessage> sendMessageFunc, int dataMinerID)
+		{
+			GetMADParameterGroupsMessage request = new GetMADParameterGroupsMessage()
+			{
+				DataMinerID = dataMinerID,
+			};
+
+			return sendMessageFunc(request) as GetMADParameterGroupsResponseMessage;
+		}
+
+		private static MADGroupInfo FetchParameterGroupInfo(Func<DMSMessage, DMSMessage> sendMessageFunc,
+			int dataMinerID,
+			string groupName)
+		{
+			GetMADParameterGroupInfoMessage msg = new GetMADParameterGroupInfoMessage(groupName)
+			{
+				DataMinerID = dataMinerID,
+			};
+
+			var response = sendMessageFunc(sendMessageFunc(msg)) as GetMADParameterGroupInfoResponseMessage;
+			return response?.GroupInfo;
+		}
+
+		private static GetMADDataResponseMessage FetchRADData(Func<DMSMessage, DMSMessage> sendMessageFunc,
+			int dataMinerID,
+			string groupName,
+			DateTime startTime,
+			DateTime endTime)
+		{
+			GetMADDataMessage msg = new GetMADDataMessage(groupName, startTime, endTime)
+			{
+				DataMinerID = dataMinerID,
+			};
+			return sendMessageFunc(sendMessageFunc(msg)) as GetMADDataResponseMessage;
+		}
+
+		private static RemoveRADParameterGroupResponseMessage RemoveParameterGroup(
+			Func<DMSMessage, DMSMessage> sendMessageFunc,
+			int dataMinerID,
+			string groupName)
+		{
+			var request = new RemoveMADParameterGroupMessage(groupName)
+			{
+				DataMinerID = dataMinerID,
+			};
+			return sendMessageFunc(request) as RemoveRADParameterGroupResponseMessage;
+		}
+
+		private static AddRADParameterGroupResponseMessage AddParameterGroup(
+			Func<DMSMessage, DMSMessage> sendMessageFunc,
+			MADGroupInfo groupInfo)
+		{
+			var request = new AddMADParameterGroupMessage(groupInfo);
+			return sendMessageFunc(request) as AddRADParameterGroupResponseMessage;
+		}
+
+		private static RetrainMADModelResponseMessage RetrainParameterGroup(
+			Func<DMSMessage, DMSMessage> sendMessageFunc,
+			int dataMinerID,
+			string groupName,
+			List<TimeRange> timeRanges)
+		{
+			var request = new RetrainMADModelMessage(groupName, timeRanges)
+			{
+				DataMinerID = dataMinerID,
+			};
+			return sendMessageFunc(request) as RetrainMADModelResponseMessage;
+		}
+#pragma warning restore CS0618 // Type or member is obsolete
+	}
+}

--- a/RadUtils/RadMessageHelper.cs
+++ b/RadUtils/RadMessageHelper.cs
@@ -1,4 +1,4 @@
-﻿namespace RadDataSourceUtils
+﻿namespace RadUtils
 {
 	using System;
 	using System.Collections.Generic;
@@ -73,7 +73,6 @@
 			return RetrainParameterGroup(engine.SendSLNetSingleResponseMessage, dataMinerID, groupName, timeRanges);
 		}
 
-
 #pragma warning disable CS0618 // Type or member is obsolete: messages are obsolete since 10.5.5, but replacements were only added in that version
 		private static GetMADParameterGroupsResponseMessage FetchParameterGroups(Func<DMSMessage, DMSMessage> sendMessageFunc, int dataMinerID)
 		{
@@ -85,7 +84,8 @@
 			return sendMessageFunc(request) as GetMADParameterGroupsResponseMessage;
 		}
 
-		private static MADGroupInfo FetchParameterGroupInfo(Func<DMSMessage, DMSMessage> sendMessageFunc,
+		private static MADGroupInfo FetchParameterGroupInfo(
+			Func<DMSMessage, DMSMessage> sendMessageFunc,
 			int dataMinerID,
 			string groupName)
 		{
@@ -98,7 +98,8 @@
 			return response?.GroupInfo;
 		}
 
-		private static GetMADDataResponseMessage FetchRADData(Func<DMSMessage, DMSMessage> sendMessageFunc,
+		private static GetMADDataResponseMessage FetchRADData(
+			Func<DMSMessage, DMSMessage> sendMessageFunc,
 			int dataMinerID,
 			string groupName,
 			DateTime startTime,

--- a/RadUtils/RadMessageHelper.cs
+++ b/RadUtils/RadMessageHelper.cs
@@ -89,12 +89,12 @@
 			int dataMinerID,
 			string groupName)
 		{
-			GetMADParameterGroupInfoMessage msg = new GetMADParameterGroupInfoMessage(groupName)
+			GetMADParameterGroupInfoMessage request = new GetMADParameterGroupInfoMessage(groupName)
 			{
 				DataMinerID = dataMinerID,
 			};
 
-			var response = sendMessageFunc(sendMessageFunc(msg)) as GetMADParameterGroupInfoResponseMessage;
+			var response = sendMessageFunc(request) as GetMADParameterGroupInfoResponseMessage;
 			return response?.GroupInfo;
 		}
 
@@ -105,11 +105,11 @@
 			DateTime startTime,
 			DateTime endTime)
 		{
-			GetMADDataMessage msg = new GetMADDataMessage(groupName, startTime, endTime)
+			GetMADDataMessage request = new GetMADDataMessage(groupName, startTime, endTime)
 			{
 				DataMinerID = dataMinerID,
 			};
-			return sendMessageFunc(sendMessageFunc(msg)) as GetMADDataResponseMessage;
+			return sendMessageFunc(request) as GetMADDataResponseMessage;
 		}
 
 		private static RemoveRADParameterGroupResponseMessage RemoveParameterGroup(

--- a/RadUtils/RadUtils.projitems
+++ b/RadUtils/RadUtils.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>2ade4ecb-223a-40e2-b795-2f33a74d70d8</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>RadDataSourceUtils</Import_RootNamespace>
+    <Import_RootNamespace>RadUtils</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Cache.cs" />

--- a/RadUtils/RadUtils.shproj
+++ b/RadUtils/RadUtils.shproj
@@ -8,6 +8,6 @@
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
   <PropertyGroup />
-  <Import Project="RadDataSourceUtils.projitems" Label="Shared" />
+  <Import Project="RadUtils.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
 </Project>

--- a/RemoveRADParameterGroup/RemoveRADParameterGroup.cs
+++ b/RemoveRADParameterGroup/RemoveRADParameterGroup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using RadDataSourceUtils;
 using RadWidgets;
 using RemoveRADParameterGroup;
 using Skyline.DataMiner.Analytics.Mad;
@@ -79,11 +80,7 @@ public class Script
 		{
 			try
 			{
-				var message = new RemoveMADParameterGroupMessage(group.Item2)
-				{
-					DataMinerID = group.Item1,
-				};
-				_app.Engine.SendSLNetSingleResponseMessage(message);
+				RadMessageHelper.RemoveParameterGroup(_app.Engine, group.Item1, group.Item2);
 			}
 			catch (Exception ex)
 			{

--- a/RemoveRADParameterGroup/RemoveRADParameterGroup.cs
+++ b/RemoveRADParameterGroup/RemoveRADParameterGroup.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using RadDataSourceUtils;
+using RadUtils;
 using RadWidgets;
 using RemoveRADParameterGroup;
-using Skyline.DataMiner.Analytics.Mad;
 using Skyline.DataMiner.Automation;
 using Skyline.DataMiner.Utils.InteractiveAutomationScript;
 
@@ -29,10 +28,10 @@ public class Script
 		{
 			_app = new InteractiveController(engine);
 
-			var groupNamesAndIds = Utils.GetGroupNameAndDataMinerID(_app);
+			var groupNamesAndIds = RadWidgets.Utils.GetGroupNameAndDataMinerID(_app);
 			if (groupNamesAndIds.Count == 0)
 			{
-				Utils.ShowMessageDialog(_app, "No parameter group selected", "Please select the parameter group you want to remove first");
+				RadWidgets.Utils.ShowMessageDialog(_app, "No parameter group selected", "Please select the parameter group you want to remove first");
 				return;
 			}
 
@@ -92,7 +91,7 @@ public class Script
 		if (failedGroups.Count > 0)
 		{
 			var ex = new AggregateException("Failed to remove parameter group(s) from RAD configuration", failedGroups.Select(p => p.Item2));
-			Utils.ShowExceptionDialog(_app, $"Failed to remove {failedGroups.Select(p => p.Item1).HumanReadableJoin()}", ex);
+			RadWidgets.Utils.ShowExceptionDialog(_app, $"Failed to remove {failedGroups.Select(p => p.Item1).HumanReadableJoin()}", ex);
 			return;
 		}
 

--- a/RemoveRADParameterGroup/RemoveRADParameterGroup.csproj
+++ b/RemoveRADParameterGroup/RemoveRADParameterGroup.csproj
@@ -11,7 +11,7 @@
     <VersionComment>Initial Version</VersionComment>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.4.1" />
+    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5.2" />
     <PackageReference Include="Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit" Version="10.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/RetrainRADModel/MultiTimeRangeSelector.cs
+++ b/RetrainRADModel/MultiTimeRangeSelector.cs
@@ -3,18 +3,17 @@
 	using System;
 	using System.Globalization;
 	using RadWidgets;
-	using Skyline.DataMiner.Analytics.Mad;
 	using Skyline.DataMiner.Automation;
 	using Skyline.DataMiner.Utils.InteractiveAutomationScript;
 
 	public class TimeRangeItem : MultiSelectorItem
 	{
-		public TimeRangeItem(TimeRange range)
+		public TimeRangeItem(Skyline.DataMiner.Analytics.Mad.TimeRange range)
 		{
 			this.TimeRange = range;
 		}
 
-		public TimeRange TimeRange { get; set; }
+		public Skyline.DataMiner.Analytics.Mad.TimeRange TimeRange { get; set; }
 
 		public override string GetKey()
 		{
@@ -64,7 +63,7 @@
 			{
 				if (_startTimePicker.DateTime >= _endTimePicker.DateTime)
 					return null;
-				return new TimeRangeItem(new TimeRange(_startTimePicker.DateTime, _endTimePicker.DateTime));
+				return new TimeRangeItem(new Skyline.DataMiner.Analytics.Mad.TimeRange(_startTimePicker.DateTime, _endTimePicker.DateTime));
 			}
 		}
 

--- a/RetrainRADModel/RetrainRADModel.cs
+++ b/RetrainRADModel/RetrainRADModel.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Linq;
-using RadDataSourceUtils;
+using RadUtils;
 using RadWidgets;
 using RetrainRADModel;
-using Skyline.DataMiner.Analytics.Mad;
 using Skyline.DataMiner.Automation;
 using Skyline.DataMiner.Utils.InteractiveAutomationScript;
 
@@ -28,15 +27,15 @@ public class Script
 		{
 			_app = new InteractiveController(engine);
 
-			var groupNamesAndIds = Utils.GetGroupNameAndDataMinerID(_app);
+			var groupNamesAndIds = RadWidgets.Utils.GetGroupNameAndDataMinerID(_app);
 			if (groupNamesAndIds.Count == 0)
 			{
-				Utils.ShowMessageDialog(_app, "No parameter group selected", "Please select the parameter group you want to retrain first");
+				RadWidgets.Utils.ShowMessageDialog(_app, "No parameter group selected", "Please select the parameter group you want to retrain first");
 				return;
 			}
 			else if (groupNamesAndIds.Count > 1)
 			{
-				Utils.ShowMessageDialog(_app, "Multiple parameter groups selected", "Please select a single parameter group you want to retrain");
+				RadWidgets.Utils.ShowMessageDialog(_app, "Multiple parameter groups selected", "Please select a single parameter group you want to retrain");
 				return;
 			}
 
@@ -85,7 +84,7 @@ public class Script
 		}
 		catch (Exception ex)
 		{
-			Utils.ShowExceptionDialog(_app, "Failed to retrain parameter group", ex, dialog);
+			RadWidgets.Utils.ShowExceptionDialog(_app, "Failed to retrain parameter group", ex, dialog);
 			return;
 		}
 

--- a/RetrainRADModel/RetrainRADModel.cs
+++ b/RetrainRADModel/RetrainRADModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using RadDataSourceUtils;
 using RadWidgets;
 using RetrainRADModel;
 using Skyline.DataMiner.Analytics.Mad;
@@ -80,11 +81,7 @@ public class Script
 
 		try
 		{
-			var message = new RetrainMADModelMessage(dialog.GroupName, dialog.GetSelectedTimeRanges().ToList())
-			{
-				DataMinerID = dialog.DataMinerID,
-			};
-			_app.Engine.SendSLNetSingleResponseMessage(message);
+			RadMessageHelper.RetrainParameterGroup(_app.Engine, dialog.DataMinerID, dialog.GroupName, dialog.GetSelectedTimeRanges().ToList());
 		}
 		catch (Exception ex)
 		{

--- a/RetrainRADModel/RetrainRADModel.csproj
+++ b/RetrainRADModel/RetrainRADModel.csproj
@@ -12,7 +12,7 @@
     <VersionComment>Initial Version</VersionComment>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.4.1" />
+    <PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5.2" />
     <PackageReference Include="Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit" Version="10.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/RetrainRADModel/RetrainRadModelDialog.cs
+++ b/RetrainRADModel/RetrainRadModelDialog.cs
@@ -3,7 +3,6 @@
 	using System;
 	using System.Collections.Generic;
 	using System.Linq;
-	using Skyline.DataMiner.Analytics.Mad;
 	using Skyline.DataMiner.Automation;
 	using Skyline.DataMiner.Utils.InteractiveAutomationScript;
 
@@ -56,7 +55,7 @@
 
 		public int DataMinerID { get; private set; }
 
-		public IEnumerable<TimeRange> GetSelectedTimeRanges()
+		public IEnumerable<Skyline.DataMiner.Analytics.Mad.TimeRange> GetSelectedTimeRanges()
 		{
 			return _timeRangeSelector.GetSelected().Select(i => i.TimeRange);
 		}


### PR DESCRIPTION
Update the version of SLAnalyticsTypes. Moves all message sending to a separate static class, and suppresses warnings about deprecated messages there.